### PR TITLE
Add missing Tickers type

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+var Tickers []Ticker
+
 //Ticker represents a Ticker from hitbtc API.
 type Ticker struct {
 	Ask         float64   `json:"ask,string"`


### PR DESCRIPTION
We are currently receiving the following compile error:

```
../go-hitbtc/hitbtc.go:121:42: undefined: Tickers
```

This type was probably forgotten to be included when PR #6 was merged:

https://github.com/bitbandi/go-hitbtc/pull/6